### PR TITLE
Add debug logs & outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ GitHub action for performing file operations on selections of files.
     # Destination, required for the "copy" operation.
     destination: dest
 ```
+
+### Outputs
+
+| Name | Description | Example |
+| - | - | - |
+| `count` | Number of files matched. | `13` |

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   destination:
     required: false
     description: Destination, required for the "copy" operation.
+outputs:
+  count:
+    description: Number of files matched.
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -32190,12 +32190,13 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.copy = void 0;
+var action = __importStar(__nccwpck_require__(2186));
 var glob = __importStar(__nccwpck_require__(3664));
 var fs_1 = __nccwpck_require__(7147);
 var path_1 = __nccwpck_require__(1017);
 function copy(src, paths, dest) {
     return __awaiter(this, void 0, void 0, function () {
-        var matches, _a, matches_1, matches_1_1, file, fileStr, srcPath, destPath, destDir, e_1_1;
+        var matches, count, _a, matches_1, matches_1_1, file, fileStr, srcPath, destPath, destDir, e_1_1;
         var _b, e_1, _c, _d;
         return __generator(this, function (_e) {
             switch (_e.label) {
@@ -32203,7 +32204,9 @@ function copy(src, paths, dest) {
                     if (paths.length === 0) {
                         paths = ["**"];
                     }
+                    action.debug("Expanding paths:\n".concat(paths.join("\n")));
                     matches = glob.globStream(paths, { cwd: src, onlyFiles: true });
+                    count = 0;
                     _e.label = 1;
                 case 1:
                     _e.trys.push([1, 6, 7, 12]);
@@ -32219,10 +32222,12 @@ function copy(src, paths, dest) {
                     srcPath = (0, path_1.join)(src, fileStr);
                     destPath = (0, path_1.join)(dest, fileStr);
                     destDir = (0, path_1.dirname)(destPath);
+                    action.debug("Copying ".concat(srcPath, " to ").concat(destPath));
                     // Ensure dir exists
                     (0, fs_1.mkdirSync)(destDir, { recursive: true });
                     // Copy file
                     (0, fs_1.copyFileSync)(srcPath, destPath, fs_1.constants.COPYFILE_EXCL);
+                    count++;
                     _e.label = 4;
                 case 4:
                     _a = true;
@@ -32244,7 +32249,9 @@ function copy(src, paths, dest) {
                     if (e_1) throw e_1.error;
                     return [7 /*endfinally*/];
                 case 11: return [7 /*endfinally*/];
-                case 12: return [2 /*return*/];
+                case 12:
+                    action.debug("Copied ".concat(count, " files"));
+                    return [2 /*return*/, count];
             }
         });
     });
@@ -32322,7 +32329,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 var action = __importStar(__nccwpck_require__(2186));
 var copy_1 = __nccwpck_require__(7402);
 (function () { return __awaiter(void 0, void 0, void 0, function () {
-    var source, filesPatterns, operation, _a, destination, error_1;
+    var source, filesPatterns, operation, _a, destination, count, error_1;
     return __generator(this, function (_b) {
         switch (_b.label) {
             case 0:
@@ -32342,7 +32349,8 @@ var copy_1 = __nccwpck_require__(7402);
                 }
                 return [4 /*yield*/, (0, copy_1.copy)(source, filesPatterns, destination)];
             case 2:
-                _b.sent();
+                count = _b.sent();
+                action.setOutput("count", count);
                 return [3 /*break*/, 4];
             case 3: throw new Error("Invalid operation: ".concat(operation));
             case 4: return [3 /*break*/, 6];

--- a/src/copy.ts
+++ b/src/copy.ts
@@ -1,3 +1,4 @@
+import * as action from "@actions/core";
 import * as glob from "fast-glob";
 import { copyFileSync, mkdirSync, constants } from "fs";
 import { dirname, join } from "path";
@@ -6,15 +7,21 @@ export async function copy(src: string, paths: string[], dest: string) {
   if (paths.length === 0) {
     paths = ["**"];
   }
+  action.debug(`Expanding paths:\n${paths.join("\n")}`);
   const matches = glob.globStream(paths, { cwd: src, onlyFiles: true });
+  let count = 0;
   for await (const file of matches) {
     const fileStr = Buffer.isBuffer(file) ? file.toString("utf-8") : file;
     const srcPath = join(src, fileStr);
     const destPath = join(dest, fileStr);
     const destDir = dirname(destPath);
+    action.debug(`Copying ${srcPath} to ${destPath}`);
     // Ensure dir exists
     mkdirSync(destDir, { recursive: true });
     // Copy file
     copyFileSync(srcPath, destPath, constants.COPYFILE_EXCL);
+    count++;
   }
+  action.debug(`Copied ${count} files`);
+  return count;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,8 @@ import { copy } from "./copy";
         if (destination === "") {
           throw new Error("destination is required for the copy operation.");
         }
-        await copy(source, filesPatterns, destination);
+        const count = await copy(source, filesPatterns, destination);
+        action.setOutput("count", count);
         break;
       default:
         throw new Error(`Invalid operation: ${operation}`);


### PR DESCRIPTION
- Add debug logs for diagnosing issues.
- Add output of number of files matched by the glob patterns.